### PR TITLE
hotfix: invalid delete neighborhood method

### DIFF
--- a/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
@@ -57,7 +57,9 @@ public class NeighborhoodServiceTests {
         UUID randomUUID = UUID.randomUUID();
         neighborhood.setId(randomUUID);
 
-        NeighborhoodService neighborhoodServiceMock = Mockito.mock(NeighborhoodService.class);
-        Mockito.when(neighborhoodServiceMock.getNeighborhoodById(randomUUID)).thenReturn(neighborhood);
+        Mockito.when(neighborhoodRepository.find(Mockito.any())).thenReturn(Optional.of(neighborhood));
+        neighborhoodService.deleteNeighborhoodById(randomUUID);
+
+        Mockito.verify(neighborhoodRepository, Mockito.times(1)).delete(neighborhood);
     }
 }


### PR DESCRIPTION
Neighborhood services was a mock, so it was kind the same that testing nothing.

continue #45