### PR TITLE
feat: add post neighborhood operation

### DIFF
--- a/src/main/java/br/com/mercadolivre/desafioquality/controller/NeighborhoodController.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/controller/NeighborhoodController.java
@@ -1,17 +1,20 @@
 package br.com.mercadolivre.desafioquality.controller;
 
-import br.com.mercadolivre.desafioquality.dto.mapper.PropertyMapper;
-import br.com.mercadolivre.desafioquality.dto.response.PropertyResponseDTO;
+import br.com.mercadolivre.desafioquality.dto.NeighborhoodDTO;
 import br.com.mercadolivre.desafioquality.exceptions.DatabaseManagementException;
 import br.com.mercadolivre.desafioquality.exceptions.DatabaseReadException;
 import br.com.mercadolivre.desafioquality.exceptions.DatabaseWriteException;
+import br.com.mercadolivre.desafioquality.exceptions.DbEntryAlreadyExists;
 import br.com.mercadolivre.desafioquality.models.Neighborhood;
 import br.com.mercadolivre.desafioquality.models.Property;
 import br.com.mercadolivre.desafioquality.services.NeighborhoodService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import javax.validation.Valid;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -24,9 +27,22 @@ public class NeighborhoodController {
     private NeighborhoodService neighborhoodService;
 
     @PostMapping("/")
-    public ResponseEntity<List<Object>> postNeighborhood() throws DatabaseReadException, DatabaseManagementException {
+    public ResponseEntity<Neighborhood> postNeighborhood(
+            @RequestBody @Valid NeighborhoodDTO newNeighborhoodDTO,
+            UriComponentsBuilder uriBuilder
+    ) throws DatabaseReadException, DatabaseManagementException, DbEntryAlreadyExists, DatabaseWriteException {
 
-        return ResponseEntity.ok(new ArrayList<>());
+
+        Neighborhood newNeighborhood = newNeighborhoodDTO.toModel();
+
+        Neighborhood addedNeighborhood = neighborhoodService.createNeighborhood(newNeighborhood);
+
+        URI uri = uriBuilder
+                .path("api/v1/neighborhood/{id}")
+                .buildAndExpand(addedNeighborhood.getId())
+                .toUri();
+
+        return ResponseEntity.created(uri).build();
     }
 
     @GetMapping("/")

--- a/src/main/java/br/com/mercadolivre/desafioquality/dto/NeighborhoodDTO.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/dto/NeighborhoodDTO.java
@@ -1,21 +1,35 @@
 package br.com.mercadolivre.desafioquality.dto;
 
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Size;
+import br.com.mercadolivre.desafioquality.models.Neighborhood;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.*;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@AllArgsConstructor
+@Builder
+@Data
 public class NeighborhoodDTO {
 
     private UUID id;
 
-    @NotEmpty(message = "O bairro não pode ficar vazio! \n")
-    @Size(max = 45,message = "O comprimento do bairro não pode exceder 45 caracteres!\n")
+    @NotEmpty(message = "O bairro não pode ficar vazio!")
+    @Size(max=45, message = "O comprimento do bairro não pode exceder 45 caracteres!")
     private String nameDistrict;
 
-    @NotEmpty(message = "O valor do metro quadrado do bairro não pode ficar vazio!\n")
-    @Digits(integer = 13,fraction = 2,message = "O valor do metro quadrado não pode exceder 13 digitos!\n")
+    @NotNull(message = "O valor do metro quadrado do bairro não pode ficar vazio!")
+    @DecimalMin(value="0.0", inclusive = false, message = "O valor do metro quadrado do bairro não ser menor ou igual a zero!")
+    @Digits(integer = 13,fraction = 2,message = "O valor do metro quadrado não pode exceder 13 digitos!")
     private BigDecimal valueDistrictM2;
 
+    public Neighborhood toModel() {
+
+        return Neighborhood.builder()
+                .nameDistrict(this.nameDistrict)
+                .valueDistrictM2(this.valueDistrictM2)
+                .build();
+    }
 }

--- a/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
@@ -31,6 +31,7 @@ public class NeighborhoodRepository implements ApplicationRepository<Neighborhoo
 
     @Override
     public Optional<Neighborhood> find(UUID id) throws DatabaseReadException {
+
         Neighborhood[] neighborhoods = fileManager.readFromFile(filename, Neighborhood[].class);
 
         return Arrays.stream(neighborhoods).filter(c -> c.getId().equals(id)).findFirst();
@@ -40,17 +41,6 @@ public class NeighborhoodRepository implements ApplicationRepository<Neighborhoo
     public Neighborhood add(Neighborhood neighborhoodToAdd) throws DatabaseWriteException, DatabaseReadException, DbEntryAlreadyExists {
         List<Neighborhood> neighborhoods = read();
 
-        Optional<Neighborhood> existingNeighborhood = neighborhoods
-                .stream()
-                .filter(neighborhood -> neighborhood.getNameDistrict().equals(neighborhoodToAdd.getNameDistrict()))
-                .findFirst();
-
-        if (existingNeighborhood.isPresent()) {
-            throw new DbEntryAlreadyExists(neighborhoodToAdd
-                    .getNameDistrict()
-                    .concat(" já está cadastrado na base de dados")
-            );
-        }
 
         neighborhoodToAdd.setId(UUID.randomUUID());
         neighborhoods.add(neighborhoodToAdd);

--- a/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
@@ -31,7 +31,6 @@ public class NeighborhoodRepository implements ApplicationRepository<Neighborhoo
 
     @Override
     public Optional<Neighborhood> find(UUID id) throws DatabaseReadException {
-
         Neighborhood[] neighborhoods = fileManager.readFromFile(filename, Neighborhood[].class);
 
         return Arrays.stream(neighborhoods).filter(c -> c.getId().equals(id)).findFirst();

--- a/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/repository/NeighborhoodRepository.java
@@ -40,8 +40,16 @@ public class NeighborhoodRepository implements ApplicationRepository<Neighborhoo
     public Neighborhood add(Neighborhood neighborhoodToAdd) throws DatabaseWriteException, DatabaseReadException, DbEntryAlreadyExists {
         List<Neighborhood> neighborhoods = read();
 
-        if (neighborhoods.contains(neighborhoodToAdd)) {
-            throw new DbEntryAlreadyExists(neighborhoodToAdd.getNameDistrict().concat(" já está cadastrado na base de dados"));
+        Optional<Neighborhood> existingNeighborhood = neighborhoods
+                .stream()
+                .filter(neighborhood -> neighborhood.getNameDistrict().equals(neighborhoodToAdd.getNameDistrict()))
+                .findFirst();
+
+        if (existingNeighborhood.isPresent()) {
+            throw new DbEntryAlreadyExists(neighborhoodToAdd
+                    .getNameDistrict()
+                    .concat(" já está cadastrado na base de dados")
+            );
         }
 
         neighborhoodToAdd.setId(UUID.randomUUID());

--- a/src/main/java/br/com/mercadolivre/desafioquality/services/NeighborhoodService.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/services/NeighborhoodService.java
@@ -9,6 +9,7 @@ import br.com.mercadolivre.desafioquality.repository.NeighborhoodRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,6 +20,20 @@ public class NeighborhoodService {
     private NeighborhoodRepository neighborhoodRepository;
 
     public Neighborhood createNeighborhood(Neighborhood newNeighborhood) throws DbEntryAlreadyExists, DatabaseWriteException, DatabaseReadException {
+
+        List<Neighborhood> neighborhoods = neighborhoodRepository.read();
+
+        Optional<Neighborhood> existingNeighborhood = neighborhoods
+                .stream()
+                .filter(neighborhood -> neighborhood.getNameDistrict().equals(newNeighborhood.getNameDistrict()))
+                .findFirst();
+
+        if (existingNeighborhood.isPresent()) {
+            throw new DbEntryAlreadyExists(newNeighborhood
+                    .getNameDistrict()
+                    .concat(" já está cadastrado na base de dados")
+            );
+        }
 
         newNeighborhood.setId(UUID.randomUUID());
         return neighborhoodRepository.add(newNeighborhood);

--- a/src/main/java/br/com/mercadolivre/desafioquality/services/NeighborhoodService.java
+++ b/src/main/java/br/com/mercadolivre/desafioquality/services/NeighborhoodService.java
@@ -2,6 +2,7 @@ package br.com.mercadolivre.desafioquality.services;
 
 import br.com.mercadolivre.desafioquality.exceptions.DatabaseReadException;
 import br.com.mercadolivre.desafioquality.exceptions.DatabaseWriteException;
+import br.com.mercadolivre.desafioquality.exceptions.DbEntryAlreadyExists;
 import br.com.mercadolivre.desafioquality.exceptions.NeighborhoodNotFoundException;
 import br.com.mercadolivre.desafioquality.models.Neighborhood;
 import br.com.mercadolivre.desafioquality.repository.NeighborhoodRepository;
@@ -17,7 +18,11 @@ public class NeighborhoodService {
 
     private NeighborhoodRepository neighborhoodRepository;
 
-    public void createNeighborhood(){}
+    public Neighborhood createNeighborhood(Neighborhood newNeighborhood) throws DbEntryAlreadyExists, DatabaseWriteException, DatabaseReadException {
+
+        newNeighborhood.setId(UUID.randomUUID());
+        return neighborhoodRepository.add(newNeighborhood);
+    }
 
     public void listNeighborhood(){}
 

--- a/src/test/java/br/com/mercadolivre/desafioquality/integration/NeighborhoodIntegrationTest.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/integration/NeighborhoodIntegrationTest.java
@@ -2,12 +2,15 @@ package br.com.mercadolivre.desafioquality.integration;
 
 import br.com.mercadolivre.desafioquality.models.Neighborhood;
 import br.com.mercadolivre.desafioquality.utils.DatabaseUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -80,4 +83,23 @@ public class NeighborhoodIntegrationTest {
         Assertions.assertEquals(0, updatedNeighborhoods.length);
     }
 
+    @Test
+    @DisplayName("NeighborhoodController - POST - /api/v1/neighborhood/")
+    public void testPostNeighborhood() throws Exception {
+
+        Neighborhood neighborhood = Neighborhood.builder()
+                .nameDistrict("Vila Olímpia")
+                .valueDistrictM2(BigDecimal.valueOf(45000))
+                .build();
+
+        ObjectMapper Obj = new ObjectMapper();
+
+        String payload = Obj.writeValueAsString(neighborhood);
+
+        MvcResult response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/neighborhood/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+    }
 }

--- a/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
@@ -34,7 +34,7 @@ public class NeighborhoodServiceTests {
         Neighborhood neighborhood = new Neighborhood();
         UUID randomUUID = UUID.randomUUID();
         neighborhood.setId(randomUUID);
-        Mockito.when(neighborhoodRepository.find(any())).thenReturn(Optional.of(neighborhood));
+        Mockito.when(neighborhoodRepository.find(Mockito.any())).thenReturn(Optional.of(neighborhood));
 
         Neighborhood foundNeighborhood = neighborhoodService.getNeighborhoodById(randomUUID);
 

--- a/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
@@ -1,8 +1,6 @@
 package br.com.mercadolivre.desafioquality.service;
 
-import br.com.mercadolivre.desafioquality.exceptions.DatabaseReadException;
-import br.com.mercadolivre.desafioquality.exceptions.DatabaseWriteException;
-import br.com.mercadolivre.desafioquality.exceptions.NeighborhoodNotFoundException;
+import br.com.mercadolivre.desafioquality.exceptions.*;
 import br.com.mercadolivre.desafioquality.models.Neighborhood;
 import br.com.mercadolivre.desafioquality.repository.NeighborhoodRepository;
 import br.com.mercadolivre.desafioquality.services.NeighborhoodService;
@@ -12,8 +10,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 
 public class NeighborhoodServiceTests {
 
@@ -32,22 +34,11 @@ public class NeighborhoodServiceTests {
         Neighborhood neighborhood = new Neighborhood();
         UUID randomUUID = UUID.randomUUID();
         neighborhood.setId(randomUUID);
-        Mockito.when(neighborhoodRepository.find(Mockito.any())).thenReturn(Optional.of(neighborhood));
+        Mockito.when(neighborhoodRepository.find(any())).thenReturn(Optional.of(neighborhood));
 
         Neighborhood foundNeighborhood = neighborhoodService.getNeighborhoodById(randomUUID);
 
         Assertions.assertEquals(foundNeighborhood.getId(), neighborhood.getId());
-    }
-
-    @Test
-    @DisplayName("Given an UUID from a non existing neighborhood, when call find method, then throw an error containing \"Bairro não encontrado\"")
-    public void testFindNonExistingNeighborhoodFromRandomUUID() {
-        Exception thrown = Assertions.assertThrows(
-                NeighborhoodNotFoundException.class,
-                () -> neighborhoodService.getNeighborhoodById(UUID.fromString("2999537f-11dc-40c1-a834-7249f2a361dd"))
-        );
-
-        Assertions.assertEquals("Bairro não encontrado", thrown.getMessage());
     }
 
     @Test
@@ -61,40 +52,20 @@ public class NeighborhoodServiceTests {
         Mockito.when(neighborhoodServiceMock.getNeighborhoodById(randomUUID)).thenReturn(neighborhood);
     }
 
-//    @Test
-//    @DisplayName("Given a valid neighborhood, when call createNeighborhood, then return ")
-//    public void testIfNeighborhoodIsCreated() throws DatabaseManagementException, DatabaseWriteException, DbEntryAlreadyExists, DatabaseReadException {
-//
-//        Neighborhood neighborhoodOne = Neighborhood
-//                .builder()
-//                .nameDistrict("Vila Maria")
-//                .valueDistrictM2(BigDecimal.valueOf(10000.0))
-//                .build();
-//
-//        Mockito.when(this.repository.add(any())).thenReturn(neighborhoodOne);
-//
-//        Neighborhood testResult = this.service.createNeighborhood(neighborhoodOne);
-//
-//        assertNotNull(testResult);
-//    }
-//
-//    @Test
-//    @DisplayName("Given a duplicated neighborhood, when call createNeighborhood, the trhows an DbEntryAlreadyExists")
-//    public void testIfThrowsErrorWhenNeighborhoodAlreadyRegistred() throws DatabaseWriteException, DbEntryAlreadyExists, DatabaseReadException, DatabaseManagementException {
-//
-//        Neighborhood neighborhoodOne = Neighborhood
-//                .builder()
-//                .nameDistrict("Vila Maria")
-//                .valueDistrictM2(BigDecimal.valueOf(10000.0))
-//                .build();
-//
-//        List<Neighborhood> neighborhoods = new ArrayList<>();
-//        neighborhoods.add(Neighborhood.builder().nameDistrict("Vila Maria").build());
-//
-//        Neighborhood nei = this.service.createNeighborhood(neighborhoodOne);
-//
-//        Throwable exception = assertThrows(DbEntryAlreadyExists.class, ()->this.service.createNeighborhood(neighborhoodOne));
-//                this.service.createNeighborhood(neighborhoodOne);
-//
-//    }
+    @Test
+    @DisplayName("Given a valid neighborhood, when call createNeighborhood, then createNeighborhood must be called once")
+    public void testIfNeighborhoodIsCreated() throws DatabaseWriteException, DbEntryAlreadyExists, DatabaseReadException {
+
+        Neighborhood neighborhoodOne = Neighborhood
+                .builder()
+                .nameDistrict("Vila Maria")
+                .valueDistrictM2(BigDecimal.valueOf(10000.0))
+                .build();
+
+        Mockito.when(this.neighborhoodRepository.add(any())).thenReturn(neighborhoodOne);
+
+        Neighborhood testResult = this.neighborhoodService.createNeighborhood(neighborhoodOne);
+
+        Mockito.verify(neighborhoodRepository, Mockito.times(1)).add(neighborhoodOne);
+    }
 }

--- a/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
@@ -42,6 +42,17 @@ public class NeighborhoodServiceTests {
     }
 
     @Test
+    @DisplayName("Given an UUID from a non existing neighborhood, when call find method, then throw an error containing \"Bairro não encontrado\"")
+    public void testFindNonExistingNeighborhoodFromRandomUUID() {
+        Exception thrown = Assertions.assertThrows(
+                NeighborhoodNotFoundException.class,
+                () -> neighborhoodService.getNeighborhoodById(UUID.fromString("2999537f-11dc-40c1-a834-7249f2a361dd"))
+        );
+
+        Assertions.assertEquals("Bairro não encontrado", thrown.getMessage());
+    }
+
+    @Test
     @DisplayName("Given an neighborhood id, when call delete method, then getNeighborhoodById must be called once")
     public void testDeleteMethodWasCalled() throws DatabaseReadException, DatabaseWriteException {
         Neighborhood neighborhood = new Neighborhood();

--- a/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
+++ b/src/test/java/br/com/mercadolivre/desafioquality/service/NeighborhoodServiceTests.java
@@ -60,4 +60,41 @@ public class NeighborhoodServiceTests {
         NeighborhoodService neighborhoodServiceMock = Mockito.mock(NeighborhoodService.class);
         Mockito.when(neighborhoodServiceMock.getNeighborhoodById(randomUUID)).thenReturn(neighborhood);
     }
+
+//    @Test
+//    @DisplayName("Given a valid neighborhood, when call createNeighborhood, then return ")
+//    public void testIfNeighborhoodIsCreated() throws DatabaseManagementException, DatabaseWriteException, DbEntryAlreadyExists, DatabaseReadException {
+//
+//        Neighborhood neighborhoodOne = Neighborhood
+//                .builder()
+//                .nameDistrict("Vila Maria")
+//                .valueDistrictM2(BigDecimal.valueOf(10000.0))
+//                .build();
+//
+//        Mockito.when(this.repository.add(any())).thenReturn(neighborhoodOne);
+//
+//        Neighborhood testResult = this.service.createNeighborhood(neighborhoodOne);
+//
+//        assertNotNull(testResult);
+//    }
+//
+//    @Test
+//    @DisplayName("Given a duplicated neighborhood, when call createNeighborhood, the trhows an DbEntryAlreadyExists")
+//    public void testIfThrowsErrorWhenNeighborhoodAlreadyRegistred() throws DatabaseWriteException, DbEntryAlreadyExists, DatabaseReadException, DatabaseManagementException {
+//
+//        Neighborhood neighborhoodOne = Neighborhood
+//                .builder()
+//                .nameDistrict("Vila Maria")
+//                .valueDistrictM2(BigDecimal.valueOf(10000.0))
+//                .build();
+//
+//        List<Neighborhood> neighborhoods = new ArrayList<>();
+//        neighborhoods.add(Neighborhood.builder().nameDistrict("Vila Maria").build());
+//
+//        Neighborhood nei = this.service.createNeighborhood(neighborhoodOne);
+//
+//        Throwable exception = assertThrows(DbEntryAlreadyExists.class, ()->this.service.createNeighborhood(neighborhoodOne));
+//                this.service.createNeighborhood(neighborhoodOne);
+//
+//    }
 }


### PR DESCRIPTION
- added `postNeighborhood` operations in Neighborhood controller
- adjusts in `NeighborhoodDTO` validations
- moves block that verifies existing neighborhood from repository to services
- changes the verification mentioned above so that the district name is now compared
- adds integration and unit tests

close #42 